### PR TITLE
BUGFIX: lost bottom layer

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,16 +1,19 @@
+4/18/2019
+  tree builder seems to be dumping the bottom row, which makes place comparisons impossible. FIX!
+
 8/17
-  Finding multiple overlaps is hard. Is there soemthing else that is worth my effort now?
+  Finding multiple overlaps is hard. Is there something else that is worth my effort now?
   In theory, if you find two things the same at an upper level, the entire subtree will match. So it's just a question of matching each level and subtracting out things already seen. That is, when you find a similarity, collect the entire subtree automatically. Then you can do stats on them, too.
   Here's the problem, though, the trees being compared might not be of the same height.
   Hmm. One interesting (implicit) assumption of a merkle tree is that EVERY element is unique. But when using text as the base, this may not hold true! (It is protected in Bitcoin because transactions have signatures applied after differing inputs and outputs. It is still theoreticallhy possible to have collisions there but it is highly unlikely). Example: suppose your bottom nodes are: ['to b', 'e or', ' not', 'to b']. Hmmmm. This actually does get you differences. Let's try again:
   ['1000', '1000', '1000', '1000'] or ['I am', ' goin', 'g to', ' go ', 'in, ', 'I am']. See? Repeated node values should be guarded against. You must guard against repeated node value sequences. One repeat makes little difference, but if a sequence of several is repeated it gives you a problem when doing comparisons later (though it should damp out in a big enough tree veentually).
   So, how to prevent? simplest possible method: add a sequence number to every bottom node. So the text example above would become:
   ['I am0', ' goin1', 'g to2', ' go 3', 'in, 4', 'I am5'], thus no 2 nodes are ever the same, even though their initializing data are the same.
-  IMPORTANT TODO: Add sequence numbers before hashing raw inputs.    
-    
+  IMPORTANT TODO: Add sequence numbers before hashing raw inputs.
+
 
 7/27
-  Against my better judgement, I added 3 files to a fixtures folder under spec, so I can test with real trees. 
+  Against my better judgement, I added 3 files to a fixtures folder under spec, so I can test with real trees.
 
 7/26
   Still working on the 2 files thing.
@@ -20,7 +23,7 @@
   Done: Started moving functions such as reading a file and making a tree out of the executable and into the Merk module. That makes it slightly easier to extend to reading another file.
   BUT FIRST: allow control of chunk size from the command line client (shouldn't get too far ahead of the capabilities in the underlying code!).
   THEN: compare two files from the command line
-  
+
 7/20
   Probably won't do much today but if I do, I'll wire up the output writer to the command line. Okay. Minimally wired up.
   NEXT: command line options specifying format should actually work? For no apparent reason i added a pretty print option. NOW I'll do command line! I'm not liking the json format. Thee. That's better!
@@ -41,7 +44,7 @@
     Have I done any work at all with command line options for this thing? Apparently not. Starting it now.
     NEXT: From the command line, read in 2 (binary) files and compare them.
     THEN: Write out results as mentioned above.
-    
+
 7/6
   Now it builds a tree with tests. Time to commit to git!
     Next: Comparing 2 trees.
@@ -58,4 +61,3 @@
   The merk gem provides tools to easily create and compare merkle trees. This is so I can explore possible uses for data validation.
   Got it so it reads in a file.
   Next: build the tree.
-

--- a/dev.log
+++ b/dev.log
@@ -1,5 +1,5 @@
 4/18/2019
-  tree builder seems to be dumping the bottom row, which makes place comparisons impossible. FIX!
+  tree builder seems to be dumping the bottom row, which makes place comparisons impossible. FIXED!
 
 8/17
   Finding multiple overlaps is hard. Is there something else that is worth my effort now?

--- a/lib/merk/mtree.rb
+++ b/lib/merk/mtree.rb
@@ -32,9 +32,16 @@ class Mtree
   # assumes raw is filled and
   # builds a merkle tree from the bottom to the top
   def make_tree
-    @tree = []  # this is where the levels of the merk tree will be stored
+      # this is where the levels of the merk tree will be stored
     layer = @raw.clone
     size = 99
+    d = Digest::SHA256.new
+    @tree = []
+    @tree << @raw.collect do |r|
+      d.reset
+      d << r.to_s
+      d.hexdigest
+    end
 
     while size > 1
       layer2 = hash_all(layer)
@@ -47,10 +54,6 @@ class Mtree
     # but doing this gives you the raw data at the top and the single-node apex at the bottom
     # this is confusing so the tree needs to be flipped upside down.
     @tree.reverse!
-    p "tree size is #{@tree.size}"
-    p @tree
-    p "*******************************"
-    @tree
   end
 
   # quick and dirty print to console
@@ -104,8 +107,3 @@ class Mtree
     new_tree
   end
 end
-
-
-# Add an array of data from the start OR
-# add one element at a time, or both.
-# start with array

--- a/lib/merk/mtree.rb
+++ b/lib/merk/mtree.rb
@@ -3,23 +3,23 @@ require_relative 'hasher'
 class Mtree
   include Merk::Hasher
   attr_reader :raw, :tree
-  
+
   def initialize(args = [])
     @raw = args
     @tree = []
 
-    make_tree unless @raw.empty?    
+    make_tree unless @raw.empty?
   end
-  
+
   def <<(arg)
     if arg.is_a?(Array)
       @raw.concat arg
-      
+
     else
       @raw << arg
     end
   end
-  
+
   # IN: a file handle and chunk size
   # Assumption: The file handle is open
   # and will be closed after we're done here.
@@ -28,7 +28,7 @@ class Mtree
       @raw << fh.read(chunk_size)
     end
   end
-  
+
   # assumes raw is filled and
   # builds a merkle tree from the bottom to the top
   def make_tree
@@ -36,30 +36,32 @@ class Mtree
     layer = @raw.clone
     size = 99
 
-    while size > 1 
+    while size > 1
       layer2 = hash_all(layer)
 
       @tree << layer2.clone
       layer = layer2.clone
       size = layer.size
     end
-    
+
     # but doing this gives you the raw data at the top and the single-node apex at the bottom
     # this is confusing so the tree needs to be flipped upside down.
     @tree.reverse!
-    
+    p "tree size is #{@tree.size}"
+    p @tree
+    p "*******************************"
     @tree
   end
-  
+
   # quick and dirty print to console
   def pp
     @tree.each do |l|
       puts l.join(", ")
     end
-    
+
     true
   end
-  
+
   def find_element(unk)
     x = -1
     y = nil
@@ -67,10 +69,10 @@ class Mtree
       x += 1
       y = @tree[x].index(unk)
     end
-    
+
     [x, y]  # @tree[x][y] = coordinates of the given element
   end
-  
+
   # extract contiguous subelements from a tree starting from the apex and working down
   # and return results as a tree. Hmmm. That means just find the bottom and allow it to build itself up.
   # IF and only if the tree is correctly formed.
@@ -80,7 +82,7 @@ class Mtree
     new_tree = Mtree.new
     new_tree.tree << [@tree[x][y]]
     num_elements = 1
-    
+
     unless y.nil?
       # extract the elements below into a new tree.
       #every level below should have twice as many elements as the current,
@@ -93,12 +95,12 @@ class Mtree
         puts " "
         num_elements *= 2
         y *= 2
-        
+
         #puts "x = #{ x}; y = #{ y}; number of elements to pull = #{ num_elements}"
         new_tree.tree << @tree[x][y, num_elements]
       end
     end
-    
+
     new_tree
   end
 end
@@ -106,4 +108,4 @@ end
 
 # Add an array of data from the start OR
 # add one element at a time, or both.
-# start with array 
+# start with array

--- a/lib/merk/version.rb
+++ b/lib/merk/version.rb
@@ -1,3 +1,3 @@
 module Merk
-  VERSION = "0.4.6b"
+  VERSION = "0.4.7"
 end

--- a/lib/merk/version.rb
+++ b/lib/merk/version.rb
@@ -1,3 +1,3 @@
 module Merk
-  VERSION = "0.4.6"
+  VERSION = "0.4.6b"
 end

--- a/merk.gemspec
+++ b/merk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/merk.gemspec
+++ b/merk.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["irving"]
   spec.email         = ["irvingthemagnificent@yahoo.com"]
   spec.summary       = %q{Tools for developing a merkle tree}
-  spec.description   = %q{Tools for comparing two digital files using a merkle tree}
+  spec.description   = %q{Tools for comparing two sets of data using a merkle tree}
   spec.homepage      = ""
   spec.license       = "MIT"
 
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/spec/merk_spec.rb
+++ b/spec/merk_spec.rb
@@ -19,9 +19,10 @@ describe Merk do
       expect(fh).to receive(:eof).and_return(true)
     end
 
-    it "should make one layer" do
+    it "should make only 1 layer above raw" do
       tree = make_tree_from(@file_name)
       expect(tree).to be_kind_of(Array)
+      expect(tree.first.size).to eq(1) # not enough data for a second node
       expect(tree.size).to eq(2)
     end
 

--- a/spec/merk_spec.rb
+++ b/spec/merk_spec.rb
@@ -5,9 +5,8 @@ describe Merk do
   it 'has a version number' do
     expect(Merk::VERSION).not_to be nil
   end
-  
+
   context "working with binary files" do
-    
     before :each do
       @file_name = "sample.png"
       fh = double(File)
@@ -20,15 +19,15 @@ describe Merk do
       expect(fh).to receive(:eof).and_return(true)
     end
 
-    it "should make one tree" do
+    it "should make one layer" do
       tree = make_tree_from(@file_name)
       expect(tree).to be_kind_of(Array)
-      expect(tree.size).to eq(1) # not enough data to make 2 nodes
+      expect(tree.size).to eq(2)
     end
-    
+
     it "should know two trees are identical" do
       tree = make_tree_from(@file_name)
-      
+
       filename2 = "someotherfile.png"
       fh = double(File)
       b1 = "a chunk of text with not too many words in it"
@@ -38,14 +37,14 @@ describe Merk do
       expect(fh).to receive(:eof).and_return(false)
       allow(fh).to receive(:read).and_return(b1)
       expect(fh).to receive(:eof).and_return(true)
-      
+
       # ******************** end set up stuff
-      
+
       tree2 = make_tree_from(filename2)
       expect(identical?(tree, tree2)).to eq(true)
-    end    
+    end
   end
-  
+
   context "working with actual files" do
     it "should return stats of non identical trees" do
       root_path = "#{ File.dirname(__FILE__) }/fixtures"
@@ -54,7 +53,7 @@ describe Merk do
       ans = comparison_stats(tree1, tree2)
       expect(ans).to be_kind_of(Hash)
       expect(ans[:match]).to eq(false)
-      expect(ans[:similarity]).to be_within(0.01).of(0.78)
-    end  
+      expect(ans[:similarity]).to be_within(0.01).of(0.81)
+    end
   end
 end

--- a/spec/mtree_spec.rb
+++ b/spec/mtree_spec.rb
@@ -8,87 +8,110 @@ describe Mtree do
       expect(m.raw).to be_kind_of(Array)
       expect(m.raw.size).to eq(0)
     end
-    
+
     it "should add passed values to raw" do
       m = Mtree.new [1, 2]
       expect(m.raw).to eq([1,2])
     end
-    
+
     it "should automatically build tree when supplied raw input" do
       m = Mtree.new [1, 2, 3, 4]
-      expect(m.tree.size).to eq(2)
+      expect(m.tree.size).to eq(3)
     end
   end
-  
+
   context "piecmeal building" do
     it "should add new values to raw" do
       m = Mtree.new
       m << 1
       expect(m.raw).to eq([1])
     end
-    
+
     it "should add multiple values to raw" do
       m = Mtree.new
       m << [1,2]
       expect(m.raw).to eq([1,2])
     end
-    
+
     it "should read in a binary file" do
       m = Mtree.new
       f = File.open "#{ File.dirname(__FILE__) }/test_files/first_birthday.png"
       m.ingest f
       expect(m.raw.size).to eq(7940)
     end
-    
+
     it "should insert rows into a tree one at a time" do
       r1 = ['aaa', 'bbb']
       r2 = ['eee']
-      
+
       m = Mtree.new
       m.tree << r1
       m.tree << r2
       expect(m.tree).to eq([r1, r2])
     end
   end
-  
+
   context "tree ops" do
     it "builds full tree" do
       list = ["one", "two", "three"]
+      level3 = make_hashes(list)
       level_two = make_tree_the_hard_way list
       top = make_tree_the_hard_way level_two
 
       m = Mtree.new list
-      expect(m.tree).to eq([top, level_two])
+      expect(m.tree).to eq([top, level_two, level3])
     end
-    
+
     it "retrieves a subtree given top node value" do
-      m = Mtree.new ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff']
+      raw = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff']
+      m = Mtree.new raw
       m.make_tree
-      #m.pp
-      result = [['a70145e430c9ffc0527e6679bd3d14c3819921c7bdcee060e3e848c1e60fe771'],
-                ['2ce109e9d0faf820b2434e166297934e6177b65ab9951dbc3e204cad4689b39c', 'fcb0de60e5febc4dea96c4dc0153362d289f1aa5bd0797db2dcd7f23708205bb']]
+      result = [["a70145e430c9ffc0527e6679bd3d14c3819921c7bdcee060e3e848c1e60fe771"],
+                ["2ce109e9d0faf820b2434e166297934e6177b65ab9951dbc3e204cad4689b39c",
+                 "fcb0de60e5febc4dea96c4dc0153362d289f1aa5bd0797db2dcd7f23708205bb"],
+                ["9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
+                 "3e744b9dc39389baf0c5a0660589b8402f3dbb49b89b3e75f2c9355852a3c677",
+                 "64daa44ad493ff28a96effab6e77f1732a3d97d83241581b37dbd70a7a4900fe",
+                 "730f75dafd73e047b86acb2dbd74e75dcb93272fa084a9082848f2341aa1abb6"]]
       m2 = m.subtree('a70145e430c9ffc0527e6679bd3d14c3819921c7bdcee060e3e848c1e60fe771')
+
+
       expect(m2).to be_kind_of(Mtree)
       expect(m2.tree).to eq(result)
     end
-    
+
     it "should find element in tree" do
       m = Mtree.new ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff']
       top_node = 'a70145e430c9ffc0527e6679bd3d14c3819921c7bdcee060e3e848c1e60fe771'
-      
+
       x, y = m.find_element top_node
       expect(x).to eq(1)
       expect(y).to eq(0)
       expect(m.tree[x][y]).to eq(top_node)
     end
-   
+
     it "should validate tree as correct"
     it "should freeze tree (make immutable) on command"
     it "should freeze tree automatically after building from raw"
   end
-  
+
+  context "sanity checking" do
+    let(:data) { ["one", "two", "three", "four", "five"] }
+    let(:tree) { Mtree.new data }
+
+    it { expect(tree.tree.size).to eq(4) }
+    it { expect(tree.tree.last.size).to eq(5) }
+    it "should have correct hashed values" do
+      data.each_with_index do |x, i|
+        d = Digest::SHA256.new
+        d << x
+        expect(tree.tree.last[i]).to eq(d.hexdigest)
+      end
+    end
+  end
+
   private
-  
+
   def make_tree_the_hard_way(from_this)
     d = Digest::SHA256.new
     out = []
@@ -101,7 +124,16 @@ describe Mtree do
       d.reset
       n += 2
     end
-    
+
     out
+  end
+
+  def make_hashes(list)
+    d = Digest::SHA256.new
+    list.collect do |item|
+      d.reset
+      d << item
+      d.hexdigest
+    end
   end
 end


### PR DESCRIPTION
This code fixes a bug that was causing the bottom layer of the tree (containing the hashes of the raw data) off. 